### PR TITLE
Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM golang:1.17-alpine as build
+WORKDIR /app
+
+# Restore modules - Start
+COPY go.mod ./
+COPY go.sum ./
+RUN go mod download
+# Restore modules - End
+
+COPY *.go ./
+COPY internal/ internal/
+COPY data/ data/
+RUN go build -ldflags="-s -w" -o /goaurrpc
+
+FROM alpine:3.15
+WORKDIR /
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "/nonexistent" \
+    --shell "/sbin/nologin" \
+    --no-create-home \
+    --uid "1000" \
+    "nonroot"
+USER nonroot:nonroot
+
+COPY sample.conf /sample.conf
+
+COPY --from=build /goaurrpc /goaurrpc
+
+ENTRYPOINT ["/goaurrpc", "-c", "/sample.conf"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN go mod download
 
 COPY *.go ./
 COPY internal/ internal/
-COPY data/ data/
 RUN go build -ldflags="-s -w" -o /goaurrpc
 
 FROM alpine:3.15

--- a/docker-compose.example.yaml
+++ b/docker-compose.example.yaml
@@ -1,0 +1,9 @@
+version: "3.9"
+
+services:
+  app:
+    build: .
+    ports:
+      - "10666:10666"
+    volumes:
+      - ./sample.conf:/sample.conf


### PR DESCRIPTION
Hey! Very cool project, thanks for making it!

I am looking to selfhost the app to use with pacseek (to improve connection speeds), I use containers for all my services as I find it easier and more organized and I think a lot of people too. So I added support for Docker to the project.

It builds using a the go:alpine image and actually runs in a small non root alpine one, so size should not be a concern, and it permits to bind a docker volume to the config in order to edit it.