### PR TITLE
chore: bump docker golang base image to 1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17-alpine as build
+FROM golang:1.18-alpine as build
 WORKDIR /app
 
 # Restore modules - Start


### PR DESCRIPTION
Since version 1.1, the docker build fails, requiring Golang base image to be at least 1.18