### PR TITLE
feat: expose last packager field

### DIFF
--- a/internal/doc/openapi_api.json
+++ b/internal/doc/openapi_api.json
@@ -442,6 +442,10 @@
           "Submitter": {
             "type": "string"
           },
+          "Packager": {
+            "type": "string",
+            "description": "From AUR web interface as `Last Packager`"
+          },
           "FirstSubmitted": {
             "type": "integer",
             "description": "UNIX timestamp"
@@ -633,6 +637,7 @@
             "makedepends",
             "maintainer",
             "submitter",
+            "packager",
             "provides",
             "conflicts",
             "replaces",
@@ -657,6 +662,7 @@
             "makedepends",
             "maintainer",
             "submitter",
+            "packager",
             "provides",
             "conflicts",
             "replaces",
@@ -729,6 +735,7 @@
                     "makedepends",
                     "maintainer",
                     "submitter",
+                    "packager",
                     "provides",
                     "conflicts",
                     "replaces",

--- a/internal/doc/openapi_rpc.json
+++ b/internal/doc/openapi_rpc.json
@@ -337,6 +337,10 @@
               "Submitter": {
                 "type": "string"
               },
+              "Packager": {
+                "type": "string",
+                "description": "From AUR web interface as `Last Packager`"
+              },
               "License": {
                 "type": "array",
                 "items": {
@@ -534,6 +538,7 @@
             "makedepends",
             "maintainer",
             "submitter",
+            "packager",
             "provides",
             "conflicts",
             "replaces",
@@ -607,6 +612,7 @@
                     "makedepends",
                     "maintainer",
                     "submitter",
+                    "packager",
                     "provides",
                     "conflicts",
                     "replaces",

--- a/internal/memdb/data.go
+++ b/internal/memdb/data.go
@@ -25,6 +25,7 @@ type PackageInfo struct {
 	OutOfDate      int      `json:"OutOfDate"`
 	Maintainer     string   `json:"Maintainer"`
 	Submitter      string   `json:"Submitter"`
+	Packager       string   `json:"Packager"`
 	FirstSubmitted int      `json:"FirstSubmitted"`
 	LastModified   int      `json:"LastModified"`
 	URLPath        string   `json:"URLPath"`

--- a/internal/memdb/memdb.go
+++ b/internal/memdb/memdb.go
@@ -161,6 +161,9 @@ func (db *MemoryDB) fillHelperVars() {
 		// submitter
 		submitter := "s-" + strings.ToLower(pkg.Submitter)
 		db.References[submitter] = append(db.References[submitter], db.PackageSlice[i])
+		// packager
+		packager := "p-" + strings.ToLower(pkg.Packager)
+		db.References[packager] = append(db.References[packager], db.PackageSlice[i])
 		// comaintainers
 		for _, com := range pkg.CoMaintainers {
 			com = "com-" + strings.ToLower(com)

--- a/internal/rpc/data.go
+++ b/internal/rpc/data.go
@@ -40,6 +40,7 @@ type InfoRecord struct {
 	Provides       []string    `json:"Provides,omitempty"`
 	Replaces       []string    `json:"Replaces,omitempty"`
 	Submitter      string      `json:"Submitter,omitempty"`
+	Packager       string      `json:"Packager,omitempty"`
 	URL            null.String `json:"URL"`
 	URLPath        null.String `json:"URLPath"`
 	Version        string      `json:"Version"`
@@ -55,6 +56,7 @@ type PackageData struct {
 	URLPath        string   `json:"URLPath,omitempty"`
 	Maintainer     string   `json:"Maintainer,omitempty"`
 	Submitter      string   `json:"Submitter,omitempty"`
+	Packager       string   `json:"Packager,omitempty"`
 	FirstSubmitted int      `json:"FirstSubmitted,omitempty"`
 	LastModified   int      `json:"LastModified,omitempty"`
 	OutOfDate      int      `json:"OutOfDate,omitempty"`
@@ -80,6 +82,7 @@ type SearchRecord struct {
 	ID             int         `json:"ID"`
 	LastModified   int         `json:"LastModified"`
 	Maintainer     null.String `json:"Maintainer"`
+	Packager       string      `json:"Packager,omitempty"`
 	Name           string      `json:"Name"`
 	NumVotes       int         `json:"NumVotes"`
 	OutOfDate      null.Int    `json:"OutOfDate"`

--- a/internal/rpc/search.go
+++ b/internal/rpc/search.go
@@ -46,6 +46,12 @@ func (s *server) search(arg, by, mode string, v6 bool) ([]string, bool) {
 				found = append(found, pkg.Name)
 			}
 		}
+	case "packager":
+		if pkgs, f := s.memDB.References["p-"+arg]; f {
+			for _, pkg := range pkgs {
+				found = append(found, pkg.Name)
+			}
+		}
 	case "depends":
 		if pkgs, f := s.memDB.References["dep-"+arg]; f {
 			for _, pkg := range pkgs {

--- a/internal/rpc/utils.go
+++ b/internal/rpc/utils.go
@@ -36,6 +36,7 @@ var queryBy = []string{
 	"name-desc",
 	"maintainer",
 	"submitter",
+	"packager",
 	"depends",
 	"makedepends",
 	"optdepends",
@@ -87,7 +88,7 @@ func validateParameters(params url.Values) error {
 	if v == "6" && len(arg) == 0 {
 		return errors.New("No request data specified.")
 	}
-	if !hasArg && !hasArgArr && by != "maintainer" {
+	if !hasArg && !hasArgArr && by != "maintainer" && by != "packager" {
 		return errors.New("No request type/data specified.")
 	}
 	if ((hasArg && len(params.Get("arg")) < 2) || (hasArgArr && len(params.Get("arg[]")) < 2)) &&
@@ -233,6 +234,7 @@ func convDbPkgToInfoRecord(dbp *db.PackageInfo) InfoRecord {
 		OutOfDate:      null.NewInt(int64(dbp.OutOfDate), dbp.OutOfDate != 0),
 		Maintainer:     null.NewString(dbp.Maintainer, dbp.Maintainer != ""),
 		Submitter:      dbp.Submitter,
+		Packager:       dbp.Packager,
 		FirstSubmitted: dbp.FirstSubmitted,
 		LastModified:   dbp.LastModified,
 		URLPath:        null.NewString(dbp.URLPath, dbp.URLPath != ""),
@@ -275,6 +277,7 @@ func convDbPkgToPackageData(dbp *db.PackageInfo) PackageData {
 		OutOfDate:      dbp.OutOfDate,
 		Maintainer:     dbp.Maintainer,
 		Submitter:      dbp.Submitter,
+		Packager:       dbp.Packager,
 		FirstSubmitted: dbp.FirstSubmitted,
 		LastModified:   dbp.LastModified,
 		URLPath:        dbp.URLPath,
@@ -303,6 +306,7 @@ func convDbPkgToSearchRecord(dbp *db.PackageInfo) SearchRecord {
 		FirstSubmitted: dbp.FirstSubmitted,
 		LastModified:   dbp.LastModified,
 		Maintainer:     null.NewString(dbp.Maintainer, dbp.Maintainer != ""),
+		Packager:       dbp.Packager,
 		Name:           dbp.Name,
 		NumVotes:       dbp.NumVotes,
 		OutOfDate:      null.NewInt(int64(dbp.OutOfDate), dbp.OutOfDate != 0),


### PR DESCRIPTION
Motivation for adding this from aurweb discussion on Matrix:

> Use case would be for Chaotic-AUR. Imagine the following situation: a package has 3 maintainers. We trust 2 of them, and one is new. Now the way it currently works is that maintainer + comaintainers are checked, if at least one isn't trusted the package is sent to human review (given it's not a simple version + checksums update).
With the last packager exposed, potential human review count could be reduced and only happen, when it's indeed the untrusted maintainer pushing an update.

Packager is not yet exposed, but I'm going to add an MR on aurweb for this as well, currently waiting for an account to be provided. Tested with a custom JSON with the field already added.